### PR TITLE
Update composer dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/console": "2.4.*@dev",
-        "guzzle/guzzle": "v3.8.1"
+        "symfony/console": "~2.4",
+        "guzzle/guzzle": "~3.8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
I recently tried to add this library to my project and Composer was complaining about using development dependencies that no longer exist.

I updated the `composer.json` file to include the stable versions of the dependencies used in this library.
