### PR TITLE
Fix ls() call caching when called multiple times in a row!

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -365,6 +365,9 @@ class Client
      */
     public function ls($key = '/', $recursive = false)
     {
+        $this->values = array();
+        $this->dirs = array();
+
         try {
             $data = $this->listDir($key, $recursive);
         } catch (EtcdException $e) {


### PR DESCRIPTION
If called twice in a row with different keys, ls() or getKeysValues() will append elements to the internal values/dirs arrays and return invalid results!